### PR TITLE
accept tf_timeout < 0 to ignore timeout

### DIFF
--- a/mbf_utility/src/navigation_utility.cpp
+++ b/mbf_utility/src/navigation_utility.cpp
@@ -67,7 +67,7 @@ bool getRobotPose(const TF &tf,
                                timeout,
                                local_pose,
                                robot_pose);
-  if (success && ros::Time::now() - robot_pose.header.stamp > timeout)
+  if (success && timeout.toSec() > 0 && ros::Time::now() - robot_pose.header.stamp > timeout)
   {
     ROS_WARN("Most recent robot pose is %gs old (tolerance %gs)",
              (ros::Time::now() - robot_pose.header.stamp).toSec(), timeout.toSec());


### PR DESCRIPTION
now tf_timeout is considered even with `-1`.
this PR ignore checking timeout when timeout is `-1`.